### PR TITLE
Functions for Fahrenheit and inHg, expanded examples

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,3 @@
-
 # Ignore editor backup files:
 *~
 *.bak
@@ -6,4 +5,3 @@
 
 # Ignore compiled Python files:
 *.pyc
-

--- a/Adafruit_BME280.py
+++ b/Adafruit_BME280.py
@@ -126,7 +126,12 @@ class BME280(object):
         if i2c is None:
             import Adafruit_GPIO.I2C as I2C
             i2c = I2C
-        self._device = i2c.get_i2c_device(address, **kwargs)
+        # Create device, catch permission errors
+        try:
+            self._device = i2c.get_i2c_device(address, **kwargs)
+        except IOError:
+            print("Unable to communicate with sensor, check permissions.")
+            exit()
         # Load calibration values.
         self._load_calibration()
         self._device.write8(BME280_REGISTER_CONTROL, 0x24)  # Sleep mode

--- a/Adafruit_BME280.py
+++ b/Adafruit_BME280.py
@@ -247,3 +247,14 @@ class BME280(object):
             h = 0
         return h
 
+    def read_temperature_f(self):
+        # Wrapper to get temp in F
+        celsius = self.read_temperature()
+        temp = celsius * 1.8 + 32
+        return temp
+
+    def read_pressure_inches(self):
+        # Wrapper to get pressure in inches of Hg
+        pascals = self.read_pressure()
+        inches = pascals * 0.0002953
+        return inches

--- a/Adafruit_BME280.py
+++ b/Adafruit_BME280.py
@@ -2,7 +2,8 @@
 # Author: Tony DiCola
 #
 # Based on the BMP280 driver with BME280 changes provided by
-# David J Taylor, Edinburgh (www.satsignal.eu)
+# David J Taylor, Edinburgh (www.satsignal.eu). Additional functions added
+# by Tom Nardi (www.digifail.com)
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -258,3 +259,16 @@ class BME280(object):
         pascals = self.read_pressure()
         inches = pascals * 0.0002953
         return inches
+
+    def read_dewpoint(self):
+        # Return calculated dewpoint in C, only accurate at > 50% RH
+        celsius = self.read_temperature()
+        humidity = self.read_humidity()
+        dewpoint = celsius - ((100 - humidity) / 5)
+        return dewpoint
+
+    def read_dewpoint_f(self):
+        # Return calculated dewpoint in F, only accurate at > 50% RH
+        dewpoint_c = self.read_dewpoint()
+        dewpoint_f = dewpoint_c * 1.8 + 32
+        return dewpoint_f


### PR DESCRIPTION
I'm working on a Pi-based weather station for uploading to Weather Underground, and their [Personal Weather Station (PWS) Protocol](http://wiki.wunderground.com/index.php/PWS_-_Upload_Protocol) only accepts temperatures in Fahrenheit and barometric pressure in inches of mercury (inHg).

So I added two simple functions which simply call the existing temperature/pressure commands and do the conversions automatically. I've also added an annotated example that demos the new functions as well as the existing ones. 
