### PR TITLE
Added setup.py to allow installation

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,10 @@
+#!/usr/bin/env python
+
+from distutils.core import setup
+
+setup(name='Adafruit_BME280',
+      version='1.0',
+      description='Adafruit Python MBE280 Liibrary',
+      url='https://github.com/adafruit/Adafruit_Python_BME280',
+      packages=['bme280', 'Adafruit_BME2180'],
+     )

--- a/setup.py
+++ b/setup.py
@@ -6,5 +6,5 @@ setup(name='Adafruit_BME280',
       version='1.0',
       description='Adafruit Python MBE280 Liibrary',
       url='https://github.com/adafruit/Adafruit_Python_BME280',
-      packages=['bme280', 'Adafruit_BME2180'],
+      py_modules=['Adafruit_BME280'],
      )

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from distutils.core import setup
 
 setup(name='Adafruit_BME280',
       version='1.0',
-      description='Adafruit Python MBE280 Liibrary',
+      description='Adafruit Python BME280 Liibrary',
       url='https://github.com/adafruit/Adafruit_Python_BME280',
       py_modules=['Adafruit_BME280'],
      )


### PR DESCRIPTION
Hey there,

Thanks for providing this super useful package! Any interest in making it installable? 
Needed it for a daemon and figured it might be useful to someone else.

This PR adds a setup.py file so as with [Adafruit_Python_GPIO](https://github.com/adafruit/Adafruit_Python_GPIO.git) can now be installed with `sudo python setup.py install`.

Cheers,

Ryan
