### PR TITLE
Fixed inconsistent data read issues and added new example

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,9 @@
+
+# Ignore editor backup files:
+*~
+*.bak
+
+
+# Ignore compiled Python files:
+*.pyc
+

--- a/Adafruit_BME280.py
+++ b/Adafruit_BME280.py
@@ -88,7 +88,7 @@ class BME280(object):
         self._device = i2c.get_i2c_device(address, **kwargs)
         # Load calibration values.
         self._load_calibration()
-        self._device.write8(BME280_REGISTER_CONTROL, 0x3F)
+        self._device.write8(BME280_REGISTER_CONTROL, 0x24)  # Sleep mode
         self.t_fine = 0.0
 
     def _load_calibration(self):

--- a/Adafruit_BME280.py
+++ b/Adafruit_BME280.py
@@ -80,6 +80,7 @@ BME280_REGISTER_CHIPID = 0xD0
 BME280_REGISTER_VERSION = 0xD1
 BME280_REGISTER_SOFTRESET = 0xE0
 
+BME280_REGISTER_STATUS = 0xF3
 BME280_REGISTER_CONTROL_HUM = 0xF2
 BME280_REGISTER_CONTROL = 0xF4
 BME280_REGISTER_CONFIG = 0xF5
@@ -182,6 +183,8 @@ class BME280(object):
         """Waits for reading to become available on device."""
         """Does a single burst read of all data values from device."""
         """Returns the raw (uncompensated) temperature from the sensor."""
+        while (self._device.readU8(BME280_REGISTER_STATUS) & 0x08):    # Wait for conversion to complete (TODO : add timeout)
+            time.sleep(0.002)
         self.BME280Data = self._device.readList(BME280_REGISTER_DATA, 8)
         raw = ((self.BME280Data[3] << 16) | (self.BME280Data[4] << 8) | self.BME280Data[5]) >> 4
         return raw

--- a/Adafruit_BME280.py
+++ b/Adafruit_BME280.py
@@ -113,11 +113,11 @@ class BME280(object):
         self.dig_H6 = self._device.readS8(BME280_REGISTER_DIG_H7)
 
         h4 = self._device.readS8(BME280_REGISTER_DIG_H4)
-        h4 = (h4 << 24) >> 20
+        h4 = (h4 << 4)
         self.dig_H4 = h4 | (self._device.readU8(BME280_REGISTER_DIG_H5) & 0x0F)
 
         h5 = self._device.readS8(BME280_REGISTER_DIG_H6)
-        h5 = (h5 << 24) >> 20
+        h5 = (h5 << 4)
         self.dig_H5 = h5 | (
         self._device.readU8(BME280_REGISTER_DIG_H5) >> 4 & 0x0F)
 

--- a/Adafruit_BME280.py
+++ b/Adafruit_BME280.py
@@ -237,7 +237,7 @@ class BME280(object):
         adc = float(self.read_raw_humidity())
         # print 'Raw humidity = {0:d}'.format (adc)
         h = float(self.t_fine) - 76800.0
-        h = (adc - (float(self.dig_H4) * 64.0 + float(self.dig_H5) / 16384.8 * h)) * (
+        h = (adc - (float(self.dig_H4) * 64.0 + float(self.dig_H5) / 16384.0 * h)) * (
         float(self.dig_H2) / 65536.0 * (1.0 + float(self.dig_H6) / 67108864.0 * h * (
         1.0 + float(self.dig_H3) / 67108864.0 * h)))
         h = h * (1.0 - float(self.dig_H1) * h / 524288.0)

--- a/Adafruit_BME280.py
+++ b/Adafruit_BME280.py
@@ -172,40 +172,40 @@ class BME280(object):
         """Gets the compensated temperature in degrees celsius."""
         # float in Python is double precision
         UT = float(self.read_raw_temp())
-        var1 = (UT / 16384.0 - self.dig_T1 / 1024.0) * float(self.dig_T2)
-        var2 = ((UT / 131072.0 - self.dig_T1 / 8192.0) * (
-        UT / 131072.0 - self.dig_T1 / 8192.0)) * float(self.dig_T3)
+        var1 = (UT / 16384.0 - float(self.dig_T1) / 1024.0) * float(self.dig_T2)
+        var2 = ((UT / 131072.0 - float(self.dig_T1) / 8192.0) * (
+        UT / 131072.0 - float(self.dig_T1) / 8192.0)) * float(self.dig_T3)
         self.t_fine = int(var1 + var2)
         temp = (var1 + var2) / 5120.0
         return temp
 
     def read_pressure(self):
         """Gets the compensated pressure in Pascals."""
-        adc = self.read_raw_pressure()
-        var1 = self.t_fine / 2.0 - 64000.0
-        var2 = var1 * var1 * self.dig_P6 / 32768.0
-        var2 = var2 + var1 * self.dig_P5 * 2.0
-        var2 = var2 / 4.0 + self.dig_P4 * 65536.0
+        adc = float(self.read_raw_pressure())
+        var1 = float(self.t_fine) / 2.0 - 64000.0
+        var2 = var1 * var1 * float(self.dig_P6) / 32768.0
+        var2 = var2 + var1 * float(self.dig_P5) * 2.0
+        var2 = var2 / 4.0 + float(self.dig_P4) * 65536.0
         var1 = (
-               self.dig_P3 * var1 * var1 / 524288.0 + self.dig_P2 * var1) / 524288.0
-        var1 = (1.0 + var1 / 32768.0) * self.dig_P1
+               float(self.dig_P3) * var1 * var1 / 524288.0 + float(self.dig_P2) * var1) / 524288.0
+        var1 = (1.0 + var1 / 32768.0) * float(self.dig_P1)
         if var1 == 0:
             return 0
         p = 1048576.0 - adc
         p = ((p - var2 / 4096.0) * 6250.0) / var1
-        var1 = self.dig_P9 * p * p / 2147483648.0
-        var2 = p * self.dig_P8 / 32768.0
-        p = p + (var1 + var2 + self.dig_P7) / 16.0
+        var1 = float(self.dig_P9) * p * p / 2147483648.0
+        var2 = p * float(self.dig_P8) / 32768.0
+        p = p + (var1 + var2 + float(self.dig_P7)) / 16.0
         return p
 
     def read_humidity(self):
-        adc = self.read_raw_humidity()
+        adc = float(self.read_raw_humidity())
         # print 'Raw humidity = {0:d}'.format (adc)
-        h = self.t_fine - 76800.0
-        h = (adc - (self.dig_H4 * 64.0 + self.dig_H5 / 16384.8 * h)) * (
-        self.dig_H2 / 65536.0 * (1.0 + self.dig_H6 / 67108864.0 * h * (
-        1.0 + self.dig_H3 / 67108864.0 * h)))
-        h = h * (1.0 - self.dig_H1 * h / 524288.0)
+        h = float(self.t_fine) - 76800.0
+        h = (adc - (float(self.dig_H4) * 64.0 + float(self.dig_H5) / 16384.8 * h)) * (
+        float(self.dig_H2) / 65536.0 * (1.0 + float(self.dig_H6) / 67108864.0 * h * (
+        1.0 + float(self.dig_H3) / 67108864.0 * h)))
+        h = h * (1.0 - float(self.dig_H1) * h / 524288.0)
         if h > 100:
             h = 100
         elif h < 0:

--- a/Adafruit_BME280_Example.py
+++ b/Adafruit_BME280_Example.py
@@ -1,6 +1,6 @@
 from Adafruit_BME280 import *
 
-sensor = BME280(mode=BME280_OSAMPLE_8)
+sensor = BME280(t_mode=BME280_OSAMPLE_8, p_mode=BME280_OSAMPLE_8, h_mode=BME280_OSAMPLE_8)
 
 degrees = sensor.read_temperature()
 pascals = sensor.read_pressure()

--- a/Adafruit_BME280_Example.py
+++ b/Adafruit_BME280_Example.py
@@ -7,7 +7,6 @@ pascals = sensor.read_pressure()
 hectopascals = pascals / 100
 humidity = sensor.read_humidity()
 
-print 'Timestamp = {0:0.3f}'.format(sensor.t_fine)
 print 'Temp      = {0:0.3f} deg C'.format(degrees)
 print 'Pressure  = {0:0.2f} hPa'.format(hectopascals)
 print 'Humidity  = {0:0.2f} %'.format(humidity)

--- a/Adafruit_BME280_Example2.py
+++ b/Adafruit_BME280_Example2.py
@@ -2,11 +2,10 @@ from Adafruit_BME280 import *
 import curses
 
 def main(stdscr):
+    sensor = BME280(p_mode=BME280_OSAMPLE_8, t_mode=BME280_OSAMPLE_2, h_mode=BME280_OSAMPLE_1, filter=BME280_FILTER_16)
     stdscr.nodelay(1)
     tstart = time.time()
     while (stdscr.getch() == -1) :
-        sensor = BME280(p_mode=BME280_OSAMPLE_8, t_mode=BME280_OSAMPLE_2, h_mode=BME280_OSAMPLE_1, filter=BME280_FILTER_16)
-
         degrees = sensor.read_temperature()
         pascals = sensor.read_pressure()
         hectopascals = pascals / 100

--- a/Adafruit_BME280_Example2.py
+++ b/Adafruit_BME280_Example2.py
@@ -1,0 +1,28 @@
+from Adafruit_BME280 import *
+import curses
+
+def main(stdscr):
+    stdscr.nodelay(1)
+    tstart = time.time()
+    while (stdscr.getch() == -1) :
+        sensor = BME280(p_mode=BME280_OSAMPLE_8, t_mode=BME280_OSAMPLE_2, h_mode=BME280_OSAMPLE_1, filter=BME280_FILTER_16)
+
+        degrees = sensor.read_temperature()
+        pascals = sensor.read_pressure()
+        hectopascals = pascals / 100
+        humidity = sensor.read_humidity()
+
+        stdscr.addstr(0, 0, 'Timestamp = %0.3f sec' % (time.time() - tstart))
+        stdscr.addstr(1, 0, 'Temp      = %0.3f deg C (%0.3f deg F)' % (degrees, ((degrees*9/5)+32)))
+        stdscr.addstr(2, 0, 'Pressure  = %0.2f hPa' % hectopascals)
+        stdscr.addstr(3, 0, 'Humidity  = %0.2f %%' % humidity)
+        stdscr.addstr(5, 0, 'Press any key to exit...')
+        stdscr.refresh()
+
+        time.sleep(3)
+
+        stdscr.erase()
+
+
+curses.wrapper(main)
+


### PR DESCRIPTION
- Fixed the inconsistent data read issue when reading values from the BME280 by doing the read as a single burst transfer as detailed in the Bosch Datasheet instead of register-by-register reads.  This mainly affected the humidity sensor reading, which previously caused it to return erroneous values.

- Switched the code to use 'normal mode' on the BME280 instead of 'forced mode' so that filtering and oversampling will work correctly.

- Added additional configuration modes for individually setting oversampling on all three sensors, and added filter and standby configuration options.

- Added new example program.

- Added .gitignore file
