### PR TITLE
Add optional argument I2C bus number

### DIFF
--- a/Adafruit_BME280.py
+++ b/Adafruit_BME280.py
@@ -90,7 +90,8 @@ BME280_REGISTER_DATA = 0xF7
 
 class BME280(object):
     def __init__(self, t_mode=BME280_OSAMPLE_1, p_mode=BME280_OSAMPLE_1, h_mode=BME280_OSAMPLE_1,
-                 standby=BME280_STANDBY_250, filter=BME280_FILTER_off, address=BME280_I2CADDR, i2c=None,
+                 standby=BME280_STANDBY_250, filter=BME280_FILTER_off, address=BME280_I2CADDR,
+                 busnum=None, i2c=None,
                  **kwargs):
         self._logger = logging.getLogger('Adafruit_BMP.BMP085')
         # Check that t_mode is valid.
@@ -128,7 +129,7 @@ class BME280(object):
             i2c = I2C
         # Create device, catch permission errors
         try:
-            self._device = i2c.get_i2c_device(address, **kwargs)
+            self._device = i2c.get_i2c_device(address, busnum, **kwargs)
         except IOError:
             print("Unable to communicate with sensor, check permissions.")
             exit()


### PR DESCRIPTION
Add ***optional*** argument for class BME280 allow user to set I2C bus number. Useful on some devices that has multiple I2C buses (e.g. Orange Pi).


Usage example

```
sensor = BME280(t_mode=BME280_OSAMPLE_16, p_mode=BME280_OSAMPLE_16, h_mode=BME280_OSAMPLE_16, address=0x76, busnum=0)
```