### PR TITLE
Catch error for bad i2c address

### DIFF
--- a/Adafruit_BME280.py
+++ b/Adafruit_BME280.py
@@ -129,6 +129,7 @@ class BME280(object):
         # Create device, catch permission errors
         try:
             self._device = i2c.get_i2c_device(address, **kwargs)
+            self._device.readRaw8()
         except IOError:
             print("Unable to communicate with sensor, check permissions.")
             exit()


### PR DESCRIPTION
The try block would not cleanly fail if a bad address was used for the sensor.  I added a basic read command to ensure it will fail if a bad address is used.